### PR TITLE
Historical conversion rates beyond 90 days

### DIFF
--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -273,9 +273,22 @@ describe "EuCentralBank" do
     }.not_to raise_error
   end
 
-	it "should accept a different store" do
-		store = double
-		bank = EuCentralBank.new(store)
+  it "should accept a different store" do
+    store = double
+    bank = EuCentralBank.new(store)
     expect(bank.store).to eq store
-	end
+  end
+
+  context 'update_historical_all_time' do
+
+    it 'finds old conversion rates beyond 90 days' do
+      @bank.update_historical_all_time
+
+      workday = Date.today - 100
+      workday -= 1 if workday.saturday?
+      workday -= 2 if workday.sunday?
+
+      @bank.exchange(100, 'GBP', 'EUR', workday)
+    end
+  end
 end

--- a/spec/eu_central_bank_spec.rb
+++ b/spec/eu_central_bank_spec.rb
@@ -288,7 +288,9 @@ describe "EuCentralBank" do
       workday -= 1 if workday.saturday?
       workday -= 2 if workday.sunday?
 
-      @bank.exchange(100, 'GBP', 'EUR', workday)
+      expect {
+        @bank.exchange(100, 'GBP', 'EUR', workday)
+      }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
# What

The ECB generously gives us conversion rates going way back to 1999. This allows us to bring all of that into the eu_central_bank gem. And as a result this would also be available to us to use in the Money implementation in mothership.

# Why is this important?

The problem is that right now we report that clickfunnels is processing billions of dollars in stripe transactions. That may or may not be true.

We are basically summing original_amount_cents regardless of original currency. This means that we are treating 600M IDR as 600M USD. When in reality 600M of IDR is about 40K of USD. 

Eventually we will index original_amount_usd into elastic so we can report via that index but this is the first step for that.

# How to test

I put in a test that passes. Basically try out a conversion from over 100 days ago. It should show up.

